### PR TITLE
Map system back/edge-swipe to Undo in X01 game and stats

### DIFF
--- a/lib/pages/games/x01_game_page.dart
+++ b/lib/pages/games/x01_game_page.dart
@@ -40,7 +40,7 @@ class _X01PageState extends State<X01Game> {
 
     return PopScope(
         canPop: false,
-        onPopInvoked: (didPop) {
+        onPopInvokedWithResult: (didPop, result) {
           if (didPop) {
             return;
           }

--- a/lib/pages/games/x01_game_page.dart
+++ b/lib/pages/games/x01_game_page.dart
@@ -40,6 +40,16 @@ class _X01PageState extends State<X01Game> {
 
     return PopScope(
         canPop: false,
+        onPopInvoked: (didPop) {
+          if (didPop) {
+            return;
+          }
+          if (data.canUndo) {
+            setState(() {
+              data.undo();
+            });
+          }
+        },
         child: Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(

--- a/lib/pages/games/x01_game_statistics.dart
+++ b/lib/pages/games/x01_game_statistics.dart
@@ -38,6 +38,13 @@ class _X01StatsState extends State<X01Statistics> {
 
     return PopScope(
         canPop: false,
+        onPopInvoked: (didPop) {
+          if (didPop) {
+            return;
+          }
+          Navigator.pop(context);
+          widget.onUndo();
+        },
         child: Scaffold(
             resizeToAvoidBottomInset: false,
             appBar: AppBar(

--- a/lib/pages/games/x01_game_statistics.dart
+++ b/lib/pages/games/x01_game_statistics.dart
@@ -38,7 +38,7 @@ class _X01StatsState extends State<X01Statistics> {
 
     return PopScope(
         canPop: false,
-        onPopInvoked: (didPop) {
+        onPopInvokedWithResult: (didPop, result) {
           if (didPop) {
             return;
           }


### PR DESCRIPTION
### Problem
System back/edge-swipe performed the default navigation pop, which unintentionally ended the game or exited views instead of triggering an undo.

---

### Fix
Intercepted the system back action via `PopScope.onPopInvoked` and mapped it to **undo actions** where appropriate.

---

### Changes
- **x01_game_page.dart**
  - On back gesture:
    - If `canUndo == true`, call `data.undo()`.
    - Prevent route pop to avoid exiting the game.

- **x01_game_statistics.dart**
  - On back gesture:
    - Pop the statistics view.
    - Call `onUndo()` to revert the last action and resume the game.

---

### Issue
Fixes #42 — Implement touch input and gestures.
